### PR TITLE
Updated script.php to also output view link

### DIFF
--- a/script.php
+++ b/script.php
@@ -353,6 +353,12 @@ if [ "$1" == "send" ]; then
     else
         echo "    ${url}${downloadpage}?h=$code&d=1"
     fi
+    echo "View download:"
+    if [[ $key_code ]]; then
+        echo "    ${url}${downloadpage}?h=$code&k=$key_code&p=1"
+    else
+        echo "    ${url}${downloadpage}?h=$code&d=1"
+    fi
     echo "Delete link:"
     echo "    ${url}${downloadpage}?h=$code&d=$del_code"
     echo


### PR DESCRIPTION
Basically just copied the direct download output case and changed d=1 to p=1 in order to generate the view action from jira instead of the direct download action.

So far I've only tested it with images (.jpg) and it seems to work just like when you normally upload an img via the web interface.

This is above and beyond my bash / js skills - but maybe someone could add a quick check on the file extension to see if it = ["jpg","png",etc] and only show the view link then..